### PR TITLE
fixed indirect import failure in getURL

### DIFF
--- a/node/getURL.js
+++ b/node/getURL.js
@@ -1,7 +1,7 @@
 var WritableStream = require("./WritableStream.js"),
 	minreq = require("minreq"),
 	url = require("url"),
-	processData = require("./index.js").process;
+	processData = require("./process.js");
 
 module.exports = function(uri, format, cb){
 	if(typeof format === "function"){


### PR DESCRIPTION
I'm not exactly sure how the dependency tree works in node but it seems you can't indirectly import scripts the way `getURL.js` was importing `process.js` (i.e. via `index.js`).  The example that it failed on was 

```
var read = require("readabilitySAX")
read.get('http://www.freep.com/article/20120213/NEWS04/202130411/1001/news', format="text", console.log) 
```

Importing it directly fixes the problem.
