### PR TITLE
getNodes() for returning text nodes of extracted text

### DIFF
--- a/browsers/DOMasSAX.js
+++ b/browsers/DOMasSAX.js
@@ -25,10 +25,10 @@ function saxParser(elem, callbacks){
 		
 		for(var i = 0; i < num; i++){
 			nodeType = childs[i].nodeType;
-			if(nodeType === 3 /*text*/)
-				callbacks.ontext(childs[i].textContent);
-			else if(nodeType === 1 /*element*/) parse(childs[i]);
-			/*else if(nodeType === 8) //comment
+			if(nodeType === Node.TEXT_NODE)
+				callbacks.ontext(childs[i]);
+			else if(nodeType === Node.ELEMENT_NODE) parse(childs[i]);
+			/*else if(nodeType === Node.COMMENT_NODE)
 				if(callbacks.oncomment) callbacks.oncomment(childs[i].toString());
 			[...]
 			*/


### PR DESCRIPTION
getNodes() can return the text nodes of the extracted content.

For example:
> readable.getArticle('nodes').nodes
has text nodes.

(whereas readable.getArticle('html') and readable.getArticle('text') do not)

Currently, even text nodes with all white space are returned. Some of these do not have an effect on the display but some can (like a space between spans).
For example, in `<span>hello</span> <span>there</span>` the space is meaningful,
but in `<p>hello</p> <p>there</p>` it is not.
In both cases, it is returned by getArticle('nodes').
