### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
-#readabilitySAX
+# readabilitySAX
 a fast and platform independent readability port
 
-##About
+## About
 This is a port of the algorithm used by the [Readability](http://code.google.com/p/arc90labs-readability/) bookmarklet to extract relevant pieces of information out of websites to a SAX parser.
 
 The advantage over other ports, e.g. [arrix/node-readability](https://github.com/arrix/node-readability), is a smaller memory footprint and a much faster execution. In my tests, most pages, even large ones, were finished within 15ms (on node, see below for more information). It works with Rhino, so it runs on [YQL](http://developer.yahoo.com/yql "Yahoo! Query Language"), which may have interesting uses. And it works within a browser.
@@ -20,13 +20,13 @@ The Readability extraction algorithm was completely ported, but some adjustments
     * Images get additional scores when their `height` or `width` attributes are high - icon sized images (<= 32px) get skipped
     * Additional classes & ids are checked
 
-##HowTo
-###Installing readabilitySAX (node)
+## HowTo
+### Installing readabilitySAX (node)
 This module is available on `npm` as `readabilitySAX`. Just run 
 
     npm install readabilitySAX
 
-#####CLI
+##### CLI
 A command line interface (CLI) may be installed via
 
     npm install -g readabilitySAX
@@ -41,8 +41,8 @@ To get this readme, just run
 
 The format is optional (it's either `text` or `html`, the default value is `text`).
 
-###Usage
-#####Node
+### Usage
+##### Node
 Just run `require("readabilitySAX")`. You'll get an object containing three methods:
 
 * `Readability(settings)`: The readability constructor. It works as a handler for `htmlparser2`. Read more about it [in the wiki](https://github.com/FB55/readabilitySAX/wiki/The-Readability-constructor)!
@@ -59,34 +59,34 @@ There are two methods available that are deprecated and __will be removed__ in a
 
 __Please don't use those two methods anymore__. Streams are the way you should build interfaces in node, and that's what I want encourage people to use.
 
-#####Browsers
+##### Browsers
 
 I started to implement simplified SAX-"parsers" for Rhino/YQL (using E4X) and the browser (using the DOM) to increase the overall performance on those platforms. The DOM version is inside the `/browsers` dir.
 
 A demo of how to use readabilitySAX inside a browser may be found at [jsFiddle](http://jsfiddle.net/pXqYR/embedded/). Some basic example files are inside the `/browsers` directory.
 
-#####YQL
+##### YQL
 
 A table using E4X-based events is available as the community table `redabilitySAX`, as well as [here](https://github.com/FB55/yql-tables/tree/master/readabilitySAX).
 
-##Parsers (on node)
+## Parsers (on node)
 Most SAX parsers (as sax.js) fail when a document is malformed XML, even if it's correct HTML. readabilitySAX should be used with [htmlparser2](http://npm.im/htmlparser2), my fork of the `htmlparser`-module (used by eg. `jsdom`), which corrects most faults. It's listed as a dependency, so npm should install it with readabilitySAX.
 
-##Performance
+## Performance
 
-#####Speed
+##### Speed
 Using a package of 724 pages from [CleanEval](http://cleaneval.sigwac.org.uk) (their website seems to be down, try to google it), readabilitySAX processed all of them in 5768 ms, that's an average of 7.97 ms per page.
 
 The benchmark was done using `tests/benchmark.js` on a MacBook (late 2010) and is probably far from perfect.
 
 Performance is the main goal of this project. The current speed should be good enough to run readabilitySAX on a singe-threaded web server with an average number of requests. That's an accomplishment!
 
-#####Accuracy
+##### Accuracy
 The main goal of CleanEval is to evaluate the accuracy of an algorithm.
 
 ___// TODO___
 
-##Todo
+## Todo
 
 - Add documentation & examples
 - Add support for URLs containing hash-bangs (`#!`)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
