### PR TITLE
Allows to set "class" in cleanAttributes

### DIFF
--- a/readabilitySAX.js
+++ b/readabilitySAX.js
@@ -417,7 +417,7 @@ Readability.prototype.onattribute = function(name, value){
 			elem.parent.attributeScore += 5;
 		}
 	}
-	else if(this._settings.cleanAttributes){
+	if(this._settings.cleanAttributes){
 		if(name in goodAttributes) elem.attributes[name] = value;
 	}
 	else elem.attributes[name] = value;


### PR DESCRIPTION
For being able to display properly the twitter widget in parsed articles, I need to set the class attribute of the blockquote as "clean", because the widget use it to know if it should display a twitter widget for the blockquote or not, for instance:

```
<blockquote class="twitter-tweet">
... 
</blockquote>
```

But even if i add "class" in "cleanAttributes" or if I disable the cleanAttribute setting the classes continue to be wiped because there is an earlier condition in the if block : 
```
	else if(name === "id" || name === "class"){
```
So if the attribute is named class it cannot be evaluated as a clean attribute or not, this PR fix that.